### PR TITLE
Use results.Found to check for successful document insertion

### DIFF
--- a/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
+++ b/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
@@ -39,6 +39,7 @@ namespace ElasticsearchInside.Tests
                 ////Assert
                 var result = client.Get<dynamic>("tester", "test-index");
                 Assert.That(result, Is.Not.Null);
+                Assert.That(result.Found);
             }
         }
 


### PR DESCRIPTION
Retrieving an non-existant document would return a non-null object and pass the test. The success of the retrieval is stored in the .Found property so it should be used for testing.