### PR TITLE
Added support for Mono under Linux

### DIFF
--- a/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
+++ b/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
@@ -12,7 +12,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_start()
         {
-            using (var elasticsearch = await new Elasticsearch(i => i.EnableLogging()).Ready())
+            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging()).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -29,7 +29,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public void Can_start_sync()
         {
-            using (var elasticsearch = new Elasticsearch(i => i.EnableLogging()).ReadySync())
+            using (var elasticsearch = new Elasticsearch(i => i.SetPort(4444).EnableLogging()).ReadySync())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -44,7 +44,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_insert_data()
         {
-            using (var elasticsearch = await new Elasticsearch(i => i.EnableLogging()).Ready())
+            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging()).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -62,7 +62,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_change_configuration()
         {
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(444).EnableLogging().LogTo(Console.WriteLine)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -72,7 +72,7 @@ namespace ElasticsearchInside.Tests
 
                 ////Assert
                 Assert.That(result.IsValid);
-                Assert.That(elasticsearch.Url.Port, Is.EqualTo(444));
+                Assert.That(elasticsearch.Url.Port, Is.EqualTo(4444));
             }
         }
         
@@ -80,7 +80,7 @@ namespace ElasticsearchInside.Tests
         public async Task Can_log_output()
         {
             var logged = false;
-            using (var elasticsearch = new Elasticsearch(c => c.EnableLogging().LogTo(message => logged = true)))
+            using (var elasticsearch = new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(message => logged = true)))
             {
                 await elasticsearch.Ready();
 
@@ -92,7 +92,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_install_plugin()
         {
-            using (var elasticsearch = await new Elasticsearch(c => c.EnableLogging().AddPlugin(new Plugin("analysis-icu"))).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().AddPlugin(new Plugin("analysis-icu"))).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -112,7 +112,7 @@ namespace ElasticsearchInside.Tests
             Settings settings;
 
             ////Act
-            using (var elasticsearch = await new Elasticsearch(c => c.EnableLogging().LogTo(Console.WriteLine)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine)).Ready())
                 settings = (Settings)elasticsearch.Settings;
 
 

--- a/source/ElasticsearchInside/Config/Plugin.cs
+++ b/source/ElasticsearchInside/Config/Plugin.cs
@@ -1,4 +1,6 @@
-﻿namespace ElasticsearchInside.Config
+﻿using System.Runtime.InteropServices;
+
+namespace ElasticsearchInside.Config
 {
     /// <summary>
     /// Defines properties needed to install a plugin.
@@ -32,7 +34,9 @@
             {
                 return $"install \"{Url}\"";
             }
-            return $"install \"{Name}\"";
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? $"install \"{Name}\""
+                : $"elasticsearch-plugin install \"{Name}\"";
         }
     }
 }

--- a/source/ElasticsearchInside/Config/Settings.cs
+++ b/source/ElasticsearchInside/Config/Settings.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,8 +28,11 @@ namespace ElasticsearchInside.Config
         }
 
         public string BuildCommandline()
-        {
-            return $"{string.Join(" ", JVMParameters)} -Des.path.home=\"{ElasticsearchHomePath.FullName}\" -cp \"lib/elasticsearch-{ElasticsearchVersion}.jar;lib/*\" \"org.elasticsearch.bootstrap.Elasticsearch\"";
+        {             
+            return
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)?
+                $"{string.Join(" ", JVMParameters)} -Des.path.home=\"{ElasticsearchHomePath.FullName}\" -cp \"lib/elasticsearch-{ElasticsearchVersion}.jar;lib/*\" \"org.elasticsearch.bootstrap.Elasticsearch\"":
+                $"{string.Join(" ", JVMParameters)} -Des.path.home=\"{ElasticsearchHomePath.FullName}\" -cp \"lib/elasticsearch-{ElasticsearchVersion}.jar:lib/*\" \"org.elasticsearch.bootstrap.Elasticsearch\"";
         }
 
         public static async Task<Settings> LoadDefault(CancellationToken cancellationToken = default(CancellationToken))

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/source/ElasticsearchInside/Utilities/Archive/ArchiveReader.cs
+++ b/source/ElasticsearchInside/Utilities/Archive/ArchiveReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,8 @@ namespace ElasticsearchInside.Utilities.Archive
         internal string ReadFileName()
         {
             var filenameLength = ReadInt32();
-            return Encoding.UTF8.GetString(ReadBytes(filenameLength));
+            var filestring = Encoding.UTF8.GetString(ReadBytes(filenameLength));
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? filestring : filestring.Replace("\\", "/");
         }
 
         internal int ReadStreamLength()

--- a/source/ElasticsearchInside/Utilities/ProcessWrapper.cs
+++ b/source/ElasticsearchInside/Utilities/ProcessWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace ElasticsearchInside.Utilities
 {
@@ -19,8 +20,8 @@ namespace ElasticsearchInside.Utilities
             {
                 UseShellExecute = false,
                 Arguments = arguments,
-                CreateNoWindow = true,
-                LoadUserProfile = false,
+                //CreateNoWindow = true,
+                //LoadUserProfile = false,
                 WorkingDirectory = workingDirectory.FullName,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,


### PR DESCRIPTION
Running the current codebase under Linux with mono raises an not-supported exception, since processes behave a bit different under Linux. 

Note that 

- binding to ports under 1024 as a non-root user is not allowed under Linux (that's why I changed it to 4444)
- java is expected to be installed on Linux for this to work as I'm using the OS Java version instead of the windows specific one (obviously).
- CreateNoWindow and LoadUserProfile are Windows specific parameters for ProcessStartInfo and can not be used under Linux or Mac. (these are the ones that gave the original exception)
- ClassPath's in java are to be set separated by : instead of ; Maybe it could work the same under Windows. I haven't tested that.

These changes allow running Elasticsearch-Inside using mono in Linux (and should also under MacOS, but that is untested). This should also allow this package to be used in .NET Core 2.0 environments (and thus Linux and MacOS).

Feel free to edit them before merging