### PR TITLE
added elasticsearch start timeout config

### DIFF
--- a/build/add-externals.ps1
+++ b/build/add-externals.ps1
@@ -79,9 +79,7 @@ function DownloadJre{
     .\tools\7z.exe x .\temp\*.tar -otemp\
 }
 
-
-
-if ($Host.Version.Major -lt 3) {
+if ($PSVersionTable.PSVersion.Major -lt 3) {
     throw "Powershell v3 or greater is required."
 }
 

--- a/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
+++ b/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
@@ -64,7 +64,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_change_configuration()
         {
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine).SetElasticsearchStartTimeout(10)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));

--- a/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
+++ b/source/ElasticsearchInside.Tests/ElasticsearchTests.cs
@@ -14,7 +14,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_start()
         {
-            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging()).Ready())
+            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging().SetElasticsearchStartTimeout(60)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -31,7 +31,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public void Can_start_sync()
         {
-            using (var elasticsearch = new Elasticsearch(i => i.SetPort(4444).EnableLogging()).ReadySync())
+            using (var elasticsearch = new Elasticsearch(i => i.SetPort(4444).EnableLogging().SetElasticsearchStartTimeout(60)).ReadySync())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -46,7 +46,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_insert_data()
         {
-            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging()).Ready())
+            using (var elasticsearch = await new Elasticsearch(i => i.SetPort(4444).EnableLogging().SetElasticsearchStartTimeout(60)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -64,7 +64,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_change_configuration()
         {
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine).SetElasticsearchStartTimeout(10)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine).SetElasticsearchStartTimeout(60)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -82,7 +82,7 @@ namespace ElasticsearchInside.Tests
         public async Task Can_log_output()
         {
             var logged = false;
-            using (var elasticsearch = new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(message => logged = true)))
+            using (var elasticsearch = new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(message => logged = true).SetElasticsearchStartTimeout(60)))
             {
                 await elasticsearch.Ready();
 
@@ -94,7 +94,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public async Task Can_install_plugin()
         {
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().AddPlugin(new Plugin("analysis-icu"))).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().AddPlugin(new Plugin("analysis-icu")).SetElasticsearchStartTimeout(60)).Ready())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -114,7 +114,7 @@ namespace ElasticsearchInside.Tests
             Settings settings;
 
             ////Act
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().LogTo(Console.WriteLine).SetElasticsearchStartTimeout(60)).Ready())
                 settings = (Settings)elasticsearch.Settings;
 
 
@@ -128,7 +128,7 @@ namespace ElasticsearchInside.Tests
         [Test]
         public void Has_specific_version()
         {
-            using (var elasticsearch = new Elasticsearch(i => i.SetPort(4444).EnableLogging()).ReadySync())
+            using (var elasticsearch = new Elasticsearch(i => i.SetPort(4444).EnableLogging().SetElasticsearchStartTimeout(60)).ReadySync())
             {
                 ////Arrange
                 var client = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
@@ -148,7 +148,7 @@ namespace ElasticsearchInside.Tests
             const string relativeSource = "TestFiles/testfile.txt";
             var sourceFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var sourcePath = Path.Combine(sourceFolder, relativeSource);
-            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().AddFile(relativeDestination, sourcePath)).Ready())
+            using (var elasticsearch = await new Elasticsearch(c => c.SetPort(4444).EnableLogging().AddFile(relativeDestination, sourcePath).SetElasticsearchStartTimeout(60)).Ready())
             {
                 var settings = (Settings)elasticsearch.Settings;
                 var folder = settings.ElasticsearchConfigPath;

--- a/source/ElasticsearchInside/Config/ISettings.cs
+++ b/source/ElasticsearchInside/Config/ISettings.cs
@@ -10,6 +10,7 @@ namespace ElasticsearchInside.Config
 
         IList<string> JVMParameters { get; }
         ISettings EnableLogging(bool enable = true);
+        ISettings SetElasticsearchStartTimeout(int timeout);
         ISettings LogTo(Action<string> logger);
 
         ISettings AddPlugin(Plugin plugin);

--- a/source/ElasticsearchInside/Config/Settings.cs
+++ b/source/ElasticsearchInside/Config/Settings.cs
@@ -164,6 +164,14 @@ namespace ElasticsearchInside.Config
 
         public bool LoggingEnabled { get; set; }
 
+        public ISettings SetElasticsearchStartTimeout(int timeout) 
+        { 
+            this.ElasticsearchStartTimeout = timeout;
+            return this;
+        }
+
+        public int ElasticsearchStartTimeout { get; set; } = 30;
+
         public Action<string> Logger { get; private set; } = message => Trace.WriteLine(message);
 
         public IList<Plugin> Plugins { get; set; } = new List<Plugin>();

--- a/source/ElasticsearchInside/Elasticsearch.cs
+++ b/source/ElasticsearchInside/Elasticsearch.cs
@@ -82,7 +82,7 @@ namespace ElasticsearchInside
             Info($"Environment ready after {_stopwatch.Elapsed.TotalSeconds} seconds");
             await StartProcess(cancellationToken).ConfigureAwait(false);
             Info("Process started");
-            await WaitForOk(cancellationToken).ConfigureAwait(false);
+            await WaitForOk(_settings.ElasticsearchStartTimeout, cancellationToken).ConfigureAwait(false);
             Info("We got ok");
             await InstallPlugins(cancellationToken).ConfigureAwait(false);
             Info("Installed plugins");
@@ -131,9 +131,9 @@ namespace ElasticsearchInside
         }
 
 
-        private async Task WaitForOk(CancellationToken cancellationToken = default(CancellationToken))
+        private async Task WaitForOk(int timeout, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
             var linked = CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, cancellationToken);
             
             var statusUrl = new UriBuilder(_settings.GetUrl())
@@ -180,7 +180,7 @@ namespace ElasticsearchInside
         {
             await _processWrapper.Restart().ConfigureAwait(false);
             await StartProcess().ConfigureAwait(false);
-            await WaitForOk().ConfigureAwait(false);
+            await WaitForOk(_settings.ElasticsearchStartTimeout).ConfigureAwait(false);
         }
 
         private async Task ExtractEmbeddedLz4Stream(string name, DirectoryInfo destination, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
fix for issue #16. 
example use: 
`elasticsearch = new ElasticsearchInside.Elasticsearch(settings => settings.SetElasticsearchStartTimeout(60));`

Changed ps script to use more reliable `$PSVersionTable` for version check.