### PR TITLE
Support for .netstandard2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Console output is by default being written to `Trace.Write` but can be customize
 ```c#
 using (new Elasticsearch(c => c.EnableLogging().LogTo(Console.WriteLine)))
 {
-                
+
 }
 ```
 
@@ -112,11 +112,12 @@ Simply add the NuGet package:
 
 ## Requirements
 
-You'll need .NET Framework 4.6.1 or later to use the precompiled binaries.
+You'll need .NET Framework 4.7.2 or later to use the precompiled binaries.
+The project also works with .net core v2.2.
 
 ## License
 
-Elasticsearch Inside is under the MIT license. 
+Elasticsearch Inside is under the MIT license.
 
 [Elasticsearch]: https://www.elastic.co/products/elasticsearch  "Elasticsearch"
 [nest]: https://github.com/elastic/elasticsearch-net  "Elasticsearch.Net & NEST"

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ Simply add the NuGet package:
 
 ## Requirements
 
-You'll need .NET Framework 4.7.2 or later to use the precompiled binaries.
-The project also works with .net core v2.2.
+This project is compiled using .net standard 2.0, which means this project will work with .NET Framework 4.6.1 (or later) or .net core 2.0 (or later).
 
 ## License
 

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -1,13 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
- <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
  <ItemGroup>
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -25,4 +25,9 @@
  <ItemGroup>
    <ProjectReference Include="..\ElasticsearchInside\ElasticsearchInside.csproj" />
  </ItemGroup>
+ <ItemGroup>
+   <None Update="TestFiles\testfile.txt">
+     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+   </None>
+ </ItemGroup>
 </Project>

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -1,75 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2BF22A5A-26A7-4AC9-9EEF-305F8ED96776}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ElasticsearchInside.Tests</RootNamespace>
-    <AssemblyName>ElasticsearchInside.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+
+ <ItemGroup>
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Config\SettingsTests.cs" />
-    <Compile Include="ElasticsearchTests.cs" />
-    <Compile Include="ProcessTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utilities\Archive\ArchiveReaderWriterTests.cs" />
-    <Compile Include="Utilities\StreamExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="TestFiles\test_plugin_135076.zip" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ElasticsearchInside\ElasticsearchInside.csproj">
-      <Project>{10914026-5bef-4407-b9fb-5b6306d81fc3}</Project>
-      <Name>ElasticsearchInside</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="TestFiles\testfile.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
+ <ItemGroup>
     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>
@@ -80,22 +19,10 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.5.0</Version>
+      <Version>3.12.0</Version>
     </PackageReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+ <ItemGroup>
+   <ProjectReference Include="..\ElasticsearchInside\ElasticsearchInside.csproj" />
+ </ItemGroup>
 </Project>

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ElasticsearchInside.Tests</RootNamespace>
     <AssemblyName>ElasticsearchInside.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -68,6 +68,20 @@
     <Content Include="TestFiles\testfile.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="lz4net">
+      <Version>1.0.15.93</Version>
+    </PackageReference>
+    <PackageReference Include="NEST">
+      <Version>6.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>9.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit">
+      <Version>3.5.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -35,22 +35,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.6.4.1\lib\net461\Elasticsearch.Net.dll</HintPath>
-    </Reference>
-    <Reference Include="LZ4PCL, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\LZ4PCL.1.0.0\lib\portable-net4+netcore45+wpa81+MonoAndroid1+MonoTouch1\LZ4PCL.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.6.4.1\lib\net461\Nest.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -69,7 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
     <None Include="TestFiles\test_plugin_135076.zip" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
+++ b/source/ElasticsearchInside.Tests/ElasticsearchInside.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
  <ItemGroup>

--- a/source/ElasticsearchInside.Tests/app.config
+++ b/source/ElasticsearchInside.Tests/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/source/ElasticsearchInside.Tests/packages.config
+++ b/source/ElasticsearchInside.Tests/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Elasticsearch.Net" version="6.4.1" targetFramework="net461" />
-  <package id="LZ4PCL" version="1.0.0" targetFramework="net451" />
-  <package id="NEST" version="6.4.1" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="NUnit" version="3.5.0" targetFramework="net461" />
-</packages>

--- a/source/ElasticsearchInside/Elasticsearch.cs
+++ b/source/ElasticsearchInside/Elasticsearch.cs
@@ -190,7 +190,7 @@ namespace ElasticsearchInside
             var started = Stopwatch.StartNew();
 
             using (var stream = GetType().Assembly.GetManifestResourceStream(typeof(RessourceTarget), name))
-            using (var decompresStream = new LZ4Stream(stream, CompressionMode.Decompress))
+            using (var decompresStream = new LZ4Stream(stream, LZ4StreamMode.Decompress))
             using (var archiveReader = new ArchiveReader(decompresStream))
                 await archiveReader.ExtractToDirectory(destination, cancellationToken).ConfigureAwait(false);
            

--- a/source/ElasticsearchInside/Elasticsearch.cs
+++ b/source/ElasticsearchInside/Elasticsearch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -11,8 +12,8 @@ using ElasticsearchInside.Config;
 using ElasticsearchInside.Executables;
 using ElasticsearchInside.Utilities;
 using ElasticsearchInside.Utilities.Archive;
-using LZ4PCL;
-using CompressionMode = LZ4PCL.CompressionMode;
+using LZ4;
+
 
 namespace ElasticsearchInside
 {

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
@@ -20,10 +20,6 @@
     <EmbeddedResource Include="Config\jvm.options" />
     <EmbeddedResource Include="Executables\elasticsearch.lz4" />
     <EmbeddedResource Include="Executables\LZ4PCL.dll" />
-  </ItemGroup>
-
- <ItemGroup>
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
  <ItemGroup>
      <PackageReference Include="lz4net">

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -1,98 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{10914026-5BEF-4407-B9FB-5B6306D81FC3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ElasticsearchInside</RootNamespace>
-    <AssemblyName>ElasticsearchInside</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
+    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Compression.FileSystem" />
+
+ <ItemGroup>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Config\Extensions.cs" />
-    <Compile Include="Config\Settings.cs" />
-    <Compile Include="Config\ISettings.cs" />
-    <Compile Include="Config\Plugin.cs" />
-    <Compile Include="Elasticsearch.cs" />
-    <Compile Include="Executables\RessourceTarget.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TimeoutWaitingForElasticsearchStatusException.cs" />
-    <Compile Include="Utilities\Archive\ArchiveReader.cs" />
-    <Compile Include="Utilities\Archive\ArchiveWriter.cs" />
-    <Compile Include="Utilities\DictionaryExtensions.cs" />
-    <Compile Include="Utilities\ProcessWrapper.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <EmbeddedResource Include="Executables\jre.lz4" />
-    <EmbeddedResource Include="Executables\elasticsearch.lz4" />
-    <EmbeddedResource Include="Config\jvm.options" />
-    <None Include="ElasticsearchInside.nuspec">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Executables\LZ4PCL.dll" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="lz4net">
+ <ItemGroup>
+     <PackageReference Include="lz4net">
       <Version>1.0.15.93</Version>
     </PackageReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -33,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LZ4PCL, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\LZ4PCL.1.0.0\lib\portable-net4+netcore45+wpa81+MonoAndroid1+MonoTouch1\LZ4PCL.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
@@ -71,7 +67,6 @@
     <None Include="ElasticsearchInside.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Executables\LZ4PCL.dll" />

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -5,6 +5,23 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Remove="Config\jvm.options" />
+    <None Remove="Executables\elasticsearch.lz4" />
+    <None Remove="Executables\jre.lz4" />
+    <None Remove="Executables\LZ4PCL.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Executables\jre.lz4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Config\jvm.options" />
+    <EmbeddedResource Include="Executables\elasticsearch.lz4" />
+    <EmbeddedResource Include="Executables\LZ4PCL.dll" />
+  </ItemGroup>
+
  <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ElasticsearchInside</RootNamespace>
     <AssemblyName>ElasticsearchInside</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -70,6 +70,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Executables\LZ4PCL.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="lz4net">
+      <Version>1.0.15.93</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/source/ElasticsearchInside/ElasticsearchInside.csproj
+++ b/source/ElasticsearchInside/ElasticsearchInside.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/ElasticsearchInside/app.config
+++ b/source/ElasticsearchInside/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/source/ElasticsearchInside/packages.config
+++ b/source/ElasticsearchInside/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="LZ4PCL" version="1.0.0" targetFramework="net451" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
I followed recommendations from Microsoft https://docs.microsoft.com/en-us/dotnet/core/porting.

This includes:

- Migrating nuget references from using `packages.config` file to embedded references in .csproj files
- Replaced incompatible LZ4PCL library with LZ4
- Upgraded .net framework to version 4.7.2
- Upgraded csproj files to compile using .netstandrard2.0

Fixes #14 and allows to fix #12 in future commits by adding more platforms.

Any comments/feedback are welcome. Thanks.